### PR TITLE
Use stderr for console.{warn,error}()

### DIFF
--- a/assembly/wasi_console.ts
+++ b/assembly/wasi_console.ts
@@ -37,14 +37,14 @@ export namespace wasi_console {
   }
 
   export function warn(message: string = ""): void {
-    let stdout = wasi_process.stdout;
+    let stdout = wasi_process.stderr;
     stdout.write("Warning: ");
     stdout.write(message);
     stdout.write("\n");
   }
 
   export function error(message: string = ""): void {
-    let stdout = wasi_process.stdout;
+    let stdout = wasi_process.stderr;
     stdout.write("Error: ");
     stdout.write(message);
     stdout.write("\n");

--- a/tests/index.js
+++ b/tests/index.js
@@ -13,7 +13,8 @@ const wasi = new WASI({
     "b": 98,
     "c": 99
   },
-  returnOnExit: true
+  returnOnExit: true,
+  version: "preview1"
 });
 const { instance } = await WebAssembly.instantiate(binary, {
   "wasi_snapshot_preview1": wasi.wasiImport


### PR DESCRIPTION
This change just makes sense.